### PR TITLE
Subscribe PitOffsetPage hooks on load lifecycle

### DIFF
--- a/Views/PitOffsetPage.xaml.cs
+++ b/Views/PitOffsetPage.xaml.cs
@@ -19,6 +19,8 @@ namespace Osadka.Views
 
             Loaded += OnLoaded;
             Unloaded += OnUnloaded;
+            Loaded += OnLoadedHook;
+            Unloaded += OnUnloadedHook;
         }
 
         private void OnLoaded(object? sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- hook PitOffsetPage load/unload events to manage view-model event subscriptions
- ensure OnOpenVectorSettingsRequested triggers OnVectorSettings which opens VectorDisplaySettingsWindow modally

## Testing
- dotnet test *(fails: `dotnet` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9601562608320b158194d079acc60