### PR TITLE
Limit PitOffset export to PNG

### DIFF
--- a/ViewModels/PitOffsetViewModel.cs
+++ b/ViewModels/PitOffsetViewModel.cs
@@ -9,7 +9,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Text;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
@@ -67,9 +66,7 @@ namespace Osadka.ViewModels
         // Команды
         public IRelayCommand LoadBackgroundCommand { get; }
         public IRelayCommand ClearBackgroundCommand { get; }
-        public IRelayCommand ExportCsvCommand { get; }
-        public IRelayCommand ExportCanvasPngCommand { get; }
-        public IRelayCommand ExportAllCommand { get; }
+        public IRelayCommand ExportPngCommand { get; }
         public IRelayCommand RefreshCommand { get; }
 
         public IRelayCommand BuildCommand { get; }
@@ -92,9 +89,7 @@ namespace Osadka.ViewModels
 
             LoadBackgroundCommand = new RelayCommand(LoadBackground);
             ClearBackgroundCommand = new RelayCommand(() => { BackgroundImage = null; BackgroundPath = null; });
-            ExportCsvCommand = new RelayCommand(ExportCsv);
-            ExportCanvasPngCommand = new RelayCommand(() => OnExportRequested?.Invoke(this, EventArgs.Empty));
-            ExportAllCommand = new RelayCommand(ExportAll);
+            ExportPngCommand = new RelayCommand(() => OnExportRequested?.Invoke(this, EventArgs.Empty));
             RefreshCommand = new RelayCommand(() => { RebuildRows(); RebuildCycleOverlays(); });
 
             BuildCommand = new RelayCommand(EnterBuildMode);
@@ -473,24 +468,6 @@ namespace Osadka.ViewModels
                 }
                 BackgroundImage = img;
             }
-        }
-
-        private void ExportCsv()
-        {
-            var dlg = new SaveFileDialog { Filter = "CSV|*.csv", FileName = "pit-offset.csv" };
-            if (dlg.ShowDialog() != true) return;
-
-            var sb = new StringBuilder();
-            sb.AppendLine("Cycle;N;X;Y;V;Dx;Dy");
-            foreach (var r in Rows)
-                sb.AppendLine($"{r.CycleId};{r.N};{r.X?.ToString(CultureInfo.InvariantCulture)};{r.Y?.ToString(CultureInfo.InvariantCulture)};{r.V?.ToString(CultureInfo.InvariantCulture)};{r.Dx?.ToString(CultureInfo.InvariantCulture)};{r.Dy?.ToString(CultureInfo.InvariantCulture)}");
-            File.WriteAllText(dlg.FileName, sb.ToString(), Encoding.UTF8);
-        }
-
-        private void ExportAll()
-        {
-            OnExportRequested?.Invoke(this, EventArgs.Empty);
-            ExportCsv();
         }
 
         // == Подгонка преобразования ==

--- a/Views/PitOffsetPage.xaml
+++ b/Views/PitOffsetPage.xaml
@@ -372,7 +372,7 @@
                         <Separator Margin="8,10"/>
 
                         <TextBlock Text="Экспорт" FontWeight="Bold"/>
-                        <Button Content="Экспорт всего (PNG+CSV)" Command="{Binding ExportAllCommand}"/>
+                        <Button Content="Экспорт PNG" Command="{Binding ExportPngCommand}"/>
                     </StackPanel>
                 </ScrollViewer>
             </Border>


### PR DESCRIPTION
## Summary
- replace the CSV and combined export commands with a single PNG export command in `PitOffsetViewModel`
- update the Pit Offset page export button to invoke the PNG-only command

## Testing
- dotnet build *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c96761d0f88320b4ca12406fdf139a