### PR TITLE
Replace cycle popup with checkable combo box

### DIFF
--- a/Controls/CheckComboBox.cs
+++ b/Controls/CheckComboBox.cs
@@ -1,0 +1,98 @@
+// File: Controls/CheckComboBox.cs
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Controls.Primitives;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Osadka.Controls
+{
+    /// <summary>
+    /// Комбобокс с поддержкой чекбоксов внутри ItemTemplate.
+    /// Не закрывает выпадающий список при клике по чекбоксу и корректно обновляет биндинги.
+    /// </summary>
+    public class CheckComboBox : ComboBox
+    {
+        static CheckComboBox()
+        {
+            DefaultStyleKeyProperty.OverrideMetadata(typeof(CheckComboBox), new FrameworkPropertyMetadata(typeof(ComboBox)));
+        }
+
+        protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            if (IsDropDownOpen && e.OriginalSource is DependencyObject source)
+            {
+                var checkBox = FindAncestor<CheckBox>(source);
+                if (checkBox != null)
+                {
+                    e.Handled = true;
+                    ToggleCheckBox(checkBox);
+                    return;
+                }
+            }
+
+            base.OnPreviewMouseLeftButtonDown(e);
+        }
+
+        protected override void OnPreviewKeyDown(KeyEventArgs e)
+        {
+            if (IsDropDownOpen && (e.Key == Key.Space || e.Key == Key.Enter))
+            {
+                if (ItemContainerGenerator.ContainerFromIndex(SelectedIndex) is DependencyObject container)
+                {
+                    var checkBox = FindDescendant<CheckBox>(container);
+                    if (checkBox != null)
+                    {
+                        e.Handled = true;
+                        ToggleCheckBox(checkBox);
+                        return;
+                    }
+                }
+            }
+
+            base.OnPreviewKeyDown(e);
+        }
+
+        private static void ToggleCheckBox(CheckBox checkBox)
+        {
+            checkBox.Focus();
+            bool newValue = !(checkBox.IsChecked ?? false);
+            checkBox.IsChecked = newValue;
+            checkBox.GetBindingExpression(ToggleButton.IsCheckedProperty)?.UpdateSource();
+        }
+
+        private static T? FindAncestor<T>(DependencyObject? start) where T : DependencyObject
+        {
+            var current = start;
+            while (current != null)
+            {
+                if (current is T typed)
+                    return typed;
+                current = VisualTreeHelper.GetParent(current);
+            }
+
+            return null;
+        }
+
+        private static T? FindDescendant<T>(DependencyObject? start) where T : DependencyObject
+        {
+            if (start == null)
+                return null;
+
+            if (start is T match)
+                return match;
+
+            int count = VisualTreeHelper.GetChildrenCount(start);
+            for (int i = 0; i < count; i++)
+            {
+                var child = VisualTreeHelper.GetChild(start, i);
+                var result = FindDescendant<T>(child);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Views/PitOffsetPage.xaml
+++ b/Views/PitOffsetPage.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:local="clr-namespace:Osadka.Views"
+             xmlns:ctrls="clr-namespace:Osadka.Controls"
              mc:Ignorable="d"
              d:DesignHeight="720" d:DesignWidth="1180">
 
@@ -306,26 +307,25 @@
                         <ComboBox ItemsSource="{Binding Objects}" SelectedItem="{Binding SelectedObject}"/>
 
                         <TextBlock Text="Циклы (включаемые)"/>
-                        <Grid>
-                            <ToggleButton x:Name="CyclesDrop"
-                                          Content="{Binding SelectedCyclesSummary}"
-                                          Padding="6" BorderBrush="#88000000" BorderThickness="1" Background="#FFF"/>
-                            <Popup PlacementTarget="{Binding ElementName=CyclesDrop}"
-                                   IsOpen="{Binding IsChecked, ElementName=CyclesDrop}"
-                                   StaysOpen="False" AllowsTransparency="True">
-                                <Border Background="White" BorderBrush="#88000000" BorderThickness="1" Padding="6" CornerRadius="6">
-                                    <ScrollViewer Height="220" Width="300">
-                                        <ItemsControl ItemsSource="{Binding Cycles}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}" Content="{Binding Id}" Margin="0,4,0,0"/>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                    </ScrollViewer>
-                                </Border>
-                            </Popup>
-                        </Grid>
+                        <ctrls:CheckComboBox ItemsSource="{Binding Cycles}"
+                                             Text="{Binding SelectedCyclesSummary, Mode=OneWay}"
+                                             IsEditable="True"
+                                             IsReadOnly="True"
+                                             StaysOpenOnEdit="True"
+                                             Padding="6"
+                                             BorderBrush="#88000000"
+                                             BorderThickness="1"
+                                             Background="White"
+                                             Width="300"
+                                             MaxDropDownHeight="220">
+                            <ctrls:CheckComboBox.ItemTemplate>
+                                <DataTemplate>
+                                    <CheckBox IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                              Content="{Binding Id}"
+                                              Margin="0,4,0,0"/>
+                                </DataTemplate>
+                            </ctrls:CheckComboBox.ItemTemplate>
+                        </ctrls:CheckComboBox>
 
                         <Separator Margin="8,10"/>
 


### PR DESCRIPTION
## Summary
- add a reusable CheckComboBox control that keeps the drop-down open when toggling checkboxes and updates bindings correctly
- use the new control on PitOffsetPage to replace the toggle/popup cycle picker and bind the summary text

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9673a1924832099f9186180c488b7