### PR TITLE
Improve pit offset rendering and vector settings integration

### DIFF
--- a/HorDeform.csproj
+++ b/HorDeform.csproj
@@ -9,6 +9,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>output-onlinepngtools.ico</ApplicationIcon>
     <FileUpgradeFlags>40</FileUpgradeFlags>
     <UpgradeBackupLocation>C:\Users\Gorji\source\repos\HorDeform\Backup\</UpgradeBackupLocation>

--- a/Views/PitConverters.cs
+++ b/Views/PitConverters.cs
@@ -6,174 +6,46 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Data;
 using System.Windows.Media;
+using Osadka.ViewModels;
 
 namespace Osadka.Views
 {
-    internal static class C
+    internal static class PitColorHelper
     {
-        public static double D(object v, double def = 0)
+        private static readonly Color[] Palette =
         {
-            if (v == null) return def;
-            if (v is double d) return d;
-            if (v is float f) return f;
-            if (v is decimal m) return (double)m;
-            if (v is int i) return i;
-            if (v is long l) return l;
-            if (v is string s && double.TryParse(s, NumberStyles.Any, CultureInfo.InvariantCulture, out var dv)) return dv;
-            var nd = v as double?;
-            return nd ?? def;
-        }
-        public static void ABT(double scale, double rotDeg, out double a, out double b)
+            Colors.Red, Colors.Blue, Colors.Green, Colors.Orange, Colors.Purple, Colors.Teal
+        };
+
+        public static Color ResolveColor(int id, VectorDisplaySettings? settings)
         {
-            var r = rotDeg * Math.PI / 180.0;
-            a = scale * Math.Cos(r);
-            b = scale * Math.Sin(r);
+            if (settings == null) return Palette[Math.Abs(id) % Palette.Length];
+            if (settings.UseSingleColor) return settings.SingleColor;
+            var style = settings.CycleStyles.FirstOrDefault(cs => cs.CycleId == id);
+            if (style != null && style.Color != Colors.Transparent) return style.Color;
+            return Palette[Math.Abs(id) % Palette.Length];
         }
-    }
 
-    // ===== Экранные координаты начала =====
-    public sealed class ToScreenConverter : IMultiValueConverter
-    {
-        public object Convert(object[] v, Type tt, object p, CultureInfo c)
+        public static SolidColorBrush CreateFrozenBrush(Color color)
         {
-            double x = C.D(v.ElementAtOrDefault(0)), y = C.D(v.ElementAtOrDefault(1));
-            double s = C.D(v.ElementAtOrDefault(2), 1), tx = C.D(v.ElementAtOrDefault(3)), ty = C.D(v.ElementAtOrDefault(4));
-            double deg = C.D(v.ElementAtOrDefault(5));
-            C.ABT(s, deg, out var a, out var b);
-            double u = a * x - b * y + tx;
-            double w = b * x + a * y + ty;
-            return (string)p == "x" ? u : w;
+            var brush = new SolidColorBrush(color);
+            brush.Freeze();
+            return brush;
         }
-        public object[] ConvertBack(object v, Type[] t, object p, CultureInfo c) => new object[] { Binding.DoNothing };
-    }
-
-    // ===== Взвешенная длина вектора (конец) =====
-    // [row, scale, offX, offY, baseScale, rotDeg, maxV, settings, settings.Version] + 'x'|'y'
-    public sealed class VectorEndWeightedConverter : IMultiValueConverter
-    {
-        public object Convert(object[] v, Type tt, object p, CultureInfo c)
-        {
-            var row = v.ElementAtOrDefault(0) as global::Osadka.ViewModels.PitPointRow;
-            if (row == null) return 0.0;
-
-            double s = C.D(v.ElementAtOrDefault(1), 1);
-            double tx = C.D(v.ElementAtOrDefault(2));
-            double ty = C.D(v.ElementAtOrDefault(3));
-            double baseScale = C.D(v.ElementAtOrDefault(4), 1);
-            double deg = C.D(v.ElementAtOrDefault(5));
-            double maxV = C.D(v.ElementAtOrDefault(6));
-            var settings = v.ElementAtOrDefault(7) as global::Osadka.ViewModels.VectorDisplaySettings;
-
-            double vlen = Math.Sqrt(Math.Pow(row.Dx ?? 0, 2) + Math.Pow(row.Dy ?? 0, 2));
-            double w = 1.0;
-            if (settings != null && settings.UseRelativeWeight && maxV > 1e-9 && vlen > 0)
-            {
-                double norm = vlen / maxV;                   // 0..1
-                double gamma = Math.Max(0.0, settings.WeightExponent);
-                w = Math.Pow(norm, gamma);                   // плавная кривая
-            }
-
-            double k = baseScale * w;                        // итоговый множитель в мире
-
-            // Пиксельные ограничения длины
-            if (settings != null && vlen > 0)
-            {
-                double pxLen = vlen * k * s;                 // текущая длина в пикселях
-                if (settings.MinArrowPx > 0 && pxLen < settings.MinArrowPx)
-                    k = settings.MinArrowPx / (vlen * s);
-                if (settings.MaxArrowPx > 0 && settings.MaxArrowPx >= settings.MinArrowPx && pxLen > settings.MaxArrowPx)
-                    k = settings.MaxArrowPx / (vlen * s);
-            }
-
-            // Конец в мировых координатах
-            double x2 = (row.X ?? 0) + (row.Dx ?? 0) * k;
-            double y2 = (row.Y ?? 0) + (row.Dy ?? 0) * k;
-
-            // Проекция на экран
-            C.ABT(s, deg, out var a, out var b);
-            double u = a * x2 - b * y2 + tx;
-            double w2 = b * x2 + a * y2 + ty;
-            return (string)p == "x" ? u : w2;
-        }
-        public object[] ConvertBack(object v, Type[] t, object p, CultureInfo c) => new object[] { Binding.DoNothing };
-    }
-
-    // ===== Наконечник треугольником (взвешенный) =====
-    // [row, scale, offX, offY, baseScale, headPx, rotDeg, maxV, settings, settings.Version]
-    public sealed class ArrowHeadPointsWeightedConverter : IMultiValueConverter
-    {
-        public object Convert(object[] v, Type tt, object p, CultureInfo c)
-        {
-            var row = v.ElementAtOrDefault(0) as global::Osadka.ViewModels.PitPointRow;
-            if (row == null) return null;
-
-            double s = C.D(v.ElementAtOrDefault(1), 1), tx = C.D(v.ElementAtOrDefault(2)), ty = C.D(v.ElementAtOrDefault(3));
-            double baseScale = C.D(v.ElementAtOrDefault(4), 1);
-            double headPx = C.D(v.ElementAtOrDefault(5), 12);
-            double deg = C.D(v.ElementAtOrDefault(6));
-            double maxV = C.D(v.ElementAtOrDefault(7));
-            var settings = v.ElementAtOrDefault(8) as global::Osadka.ViewModels.VectorDisplaySettings;
-
-            double vlen = Math.Sqrt(Math.Pow(row.Dx ?? 0, 2) + Math.Pow(row.Dy ?? 0, 2));
-            double w = 1.0;
-            if (settings != null && settings.UseRelativeWeight && maxV > 1e-9 && vlen > 0)
-            {
-                double norm = vlen / maxV;
-                double gamma = Math.Max(0.0, settings.WeightExponent);
-                w = Math.Pow(norm, gamma);
-            }
-            double k = baseScale * w;
-
-            if (settings != null && vlen > 0)
-            {
-                double pxLen = vlen * k * s;
-                if (settings.MinArrowPx > 0 && pxLen < settings.MinArrowPx)
-                    k = settings.MinArrowPx / (vlen * s);
-                if (settings.MaxArrowPx > 0 && settings.MaxArrowPx >= settings.MinArrowPx && pxLen > settings.MaxArrowPx)
-                    k = settings.MaxArrowPx / (vlen * s);
-            }
-
-            double x1 = (row.X ?? 0), y1 = (row.Y ?? 0);
-            double x2 = x1 + (row.Dx ?? 0) * k;
-            double y2 = y1 + (row.Dy ?? 0) * k;
-
-            C.ABT(s, deg, out var a, out var b);
-            double u1 = a * x1 - b * y1 + tx, w1 = b * x1 + a * y1 + ty;
-            double u2 = a * x2 - b * y2 + tx, w2 = b * x2 + a * y2 + ty;
-
-            var vx = u2 - u1; var vy = w2 - w1;
-            var len = Math.Sqrt(vx * vx + vy * vy);
-            if (len < 1e-6) return new PointCollection { new Point(u2, w2) };
-
-            var ux = vx / len; var uy = vy / len;
-            var nx = -uy; var ny = ux;
-            double head = Math.Min(headPx, len * 0.25);
-
-            var p0 = new Point(u2, w2);
-            var p1 = new Point(u2 - ux * head + nx * head * 0.4, w2 - uy * head + ny * head * 0.4);
-            var p2 = new Point(u2 - ux * head - nx * head * 0.4, w2 - uy * head - ny * head * 0.4);
-            return new PointCollection { p0, p1, p2 };
-        }
-        public object[] ConvertBack(object v, Type[] t, object p, CultureInfo c) => new object[] { Binding.DoNothing };
     }
 
     // ===== Цвет цикла из настроек =====
     public sealed class CycleColorFromSettingsConverter : IMultiValueConverter
     {
-        private static readonly Brush[] Palette =
-            { Brushes.Red, Brushes.Blue, Brushes.Green, Brushes.Orange, Brushes.Purple, Brushes.Teal };
-
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
             int id = values != null && values.Length > 0 && values[0] is int i ? i : 0;
-            var settings = values != null && values.Length > 1 ? values[1] as global::Osadka.ViewModels.VectorDisplaySettings : null;
-            if (settings == null) return Palette[Math.Abs(id) % Palette.Length];
-            if (settings.UseSingleColor) return new SolidColorBrush(settings.SingleColor);
-            var style = settings.CycleStyles.FirstOrDefault(cs => cs.CycleId == id);
-            if (style != null && style.Color != Colors.Transparent) return new SolidColorBrush(style.Color);
-            return Palette[Math.Abs(id) % Palette.Length];
+            var settings = values != null && values.Length > 1 ? values[1] as VectorDisplaySettings : null;
+            var color = PitColorHelper.ResolveColor(id, settings);
+            return PitColorHelper.CreateFrozenBrush(color);
         }
-        public object[] ConvertBack(object v, Type[] t, object p, CultureInfo c) => new object[] { Binding.DoNothing };
+        public object[] ConvertBack(object value, Type[] targetTypes, object parameter, CultureInfo culture)
+            => new object[] { Binding.DoNothing };
     }
 
     // ===== Штриховка (угол/шаг/прозрачность из настроек) =====
@@ -182,38 +54,58 @@ namespace Osadka.Views
     {
         public object Convert(object[] values, Type targetType, object parameter, CultureInfo culture)
         {
-            var settings = values != null && values.Length > 1 ? values[1] as global::Osadka.ViewModels.VectorDisplaySettings : null;
-            double spacing = settings?.HatchSpacingPx ?? 12;
-            double opacity = settings?.HatchOpacity ?? 0.6;
-            double angle = settings?.HatchAngleDeg ?? 45;
+            int id = values != null && values.Length > 0 && values[0] is int i ? i : 0;
+            var settings = values != null && values.Length > 1 ? values[1] as VectorDisplaySettings : null;
 
-            var stroke = Brushes.Gray;
-            if (values != null && values.Length > 0 && values[0] is int id)
-            {
-                var pal = new[] { Colors.Red, Colors.Blue, Colors.Green, Colors.Orange, Colors.Purple, Colors.Teal };
-                var c = pal[Math.Abs(id) % pal.Length];
-                stroke = new SolidColorBrush(Color.FromArgb((byte)(opacity * 255), c.R, c.G, c.B));
-            }
-            var pen = new Pen(stroke, 1);
+            double spacing = Math.Max(2.0, settings?.HatchSpacingPx ?? 12.0);
+            double fillOpacity = Math.Clamp(settings?.FillOpacity ?? 0.3, 0.0, 1.0);
+            double hatchOpacity = Math.Clamp(settings?.HatchOpacity ?? 0.6, 0.0, 1.0);
+            double angle = settings?.HatchAngleDeg ?? 45.0;
 
-            var group = new GeometryGroup();
-            int lines = 12;
-            for (int i = -lines; i <= lines; i++)
+            var baseColor = PitColorHelper.ResolveColor(id, settings);
+            var fillColor = Color.FromArgb((byte)(fillOpacity * 255), baseColor.R, baseColor.G, baseColor.B);
+            var hatchColor = Color.FromArgb((byte)(hatchOpacity * 255), baseColor.R, baseColor.G, baseColor.B);
+
+            var fillBrush = new SolidColorBrush(fillColor);
+            fillBrush.Freeze();
+            var hatchBrush = new SolidColorBrush(hatchColor);
+            hatchBrush.Freeze();
+            var pen = new Pen(hatchBrush, 1);
+            pen.Freeze();
+
+            var cell = new Rect(0, 0, spacing, spacing);
+            var background = new GeometryDrawing(fillBrush, null, new RectangleGeometry(cell));
+            background.Freeze();
+
+            var geometryGroup = new GeometryGroup();
+            for (int k = -1; k <= 1; k++)
             {
-                double x = i * spacing;
-                group.Children.Add(new LineGeometry(new Point(x, -1000), new Point(x, 1000)));
+                double offset = k * spacing;
+                var line = new LineGeometry(new Point(offset, spacing), new Point(offset + spacing, 0));
+                line.Freeze();
+                geometryGroup.Children.Add(line);
             }
-            var drawing = new GeometryDrawing(null, pen, group);
-            var brush = new DrawingBrush(drawing)
+            geometryGroup.Freeze();
+
+            var hatchDrawing = new GeometryDrawing(null, pen, geometryGroup);
+            hatchDrawing.Freeze();
+
+            var drawingGroup = new DrawingGroup();
+            drawingGroup.Children.Add(background);
+            drawingGroup.Children.Add(hatchDrawing);
+            drawingGroup.Freeze();
+
+            var brush = new DrawingBrush(drawingGroup)
             {
                 TileMode = TileMode.Tile,
-                Viewport = new Rect(0, 0, spacing, spacing),
+                Viewport = cell,
                 ViewportUnits = BrushMappingMode.Absolute,
-                Viewbox = new Rect(0, 0, spacing, spacing),
+                Viewbox = cell,
                 ViewboxUnits = BrushMappingMode.Absolute,
-                Opacity = settings?.FillOpacity ?? 0.3
+                Stretch = Stretch.None
             };
             brush.RelativeTransform = new RotateTransform(angle, 0.5, 0.5);
+            brush.Freeze();
             return brush;
         }
 

--- a/Views/PitOffsetPage.xaml
+++ b/Views/PitOffsetPage.xaml
@@ -9,11 +9,6 @@
              d:DesignHeight="720" d:DesignWidth="1180">
 
     <UserControl.Resources>
-        <!-- Проекции/стрелки с поддержкой веса -->
-        <local:ToScreenConverter x:Key="ToScreen"/>
-        <local:VectorEndWeightedConverter x:Key="VectorEndW"/>
-        <local:ArrowHeadPointsWeightedConverter x:Key="HeadW"/>
-
         <!-- Цвета/штрих/видимость -->
         <local:CycleColorFromSettingsConverter x:Key="CycleColorFromSettingsConverter"/>
         <local:CycleHatchMultiConverter x:Key="CycleHatchConverter"/>
@@ -81,38 +76,33 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Grid>
-                                    <Polygon Points="{Binding Points}"
-                                             Visibility="{Binding HasFill, Converter={StaticResource BoolToVis}}"
-                                             StrokeThickness="2"
-                                             Opacity="{Binding DataContext.VectorSettings.FillOpacity, RelativeSource={RelativeSource AncestorType=UserControl}}">
-                                        <Polygon.Stroke>
-                                            <MultiBinding Converter="{StaticResource CycleColorFromSettingsConverter}">
-                                                <Binding Path="CycleId"/>
-                                                <Binding Path="DataContext.VectorSettings" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings.Version" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            </MultiBinding>
-                                        </Polygon.Stroke>
-                                        <Polygon.Fill>
+                                    <Path Data="{Binding FillGeometry}"
+                                          Visibility="{Binding HasFill, Converter={StaticResource BoolToVis}}"
+                                          StrokeThickness="0">
+                                        <Path.Fill>
                                             <MultiBinding Converter="{StaticResource CycleHatchConverter}">
                                                 <Binding Path="CycleId"/>
                                                 <Binding Path="DataContext.VectorSettings" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
                                                 <Binding Path="DataContext.VectorSettings.Version" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
                                             </MultiBinding>
-                                        </Polygon.Fill>
-                                    </Polygon>
+                                        </Path.Fill>
+                                    </Path>
 
-                                    <!-- Фоллбек: нет площади -->
-                                    <Polyline Points="{Binding Points}"
-                                              Visibility="{Binding HasFill, Converter={StaticResource NotBoolToVis}}"
-                                              StrokeThickness="2">
-                                        <Polyline.Stroke>
+                                    <Path Data="{Binding StrokeGeometry}"
+                                          Visibility="{Binding HasStroke, Converter={StaticResource BoolToVis}}"
+                                          Fill="Transparent"
+                                          StrokeStartLineCap="Round"
+                                          StrokeEndLineCap="Round"
+                                          StrokeLineJoin="Round"
+                                          StrokeThickness="{Binding DataContext.VectorSettings.LineThickness, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                        <Path.Stroke>
                                             <MultiBinding Converter="{StaticResource CycleColorFromSettingsConverter}">
                                                 <Binding Path="CycleId"/>
                                                 <Binding Path="DataContext.VectorSettings" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
                                                 <Binding Path="DataContext.VectorSettings.Version" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
                                             </MultiBinding>
-                                        </Polyline.Stroke>
-                                    </Polyline>
+                                        </Path.Stroke>
+                                    </Path>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -128,7 +118,10 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Canvas>
-                                    <Line StrokeThickness="{Binding DataContext.VectorSettings.LineThickness, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                    <Line StrokeThickness="{Binding DataContext.VectorSettings.LineThickness, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                          StrokeStartLineCap="Round"
+                                          StrokeEndLineCap="Round"
+                                          Visibility="{Binding HasVector, Converter={StaticResource BoolToVis}}">
                                         <Line.Stroke>
                                             <MultiBinding Converter="{StaticResource CycleColorFromSettingsConverter}">
                                                 <Binding Path="CycleId"/>
@@ -137,59 +130,23 @@
                                             </MultiBinding>
                                         </Line.Stroke>
 
-                                        <!-- начало -->
                                         <Line.X1>
-                                            <MultiBinding Converter="{StaticResource ToScreen}" ConverterParameter="x">
-                                                <Binding Path="X"/>
-                                                <Binding Path="Y"/>
-                                                <Binding Path="DataContext.Scale" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetX" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetY" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.RotationDeg" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            </MultiBinding>
+                                            <Binding Path="ScreenX"/>
                                         </Line.X1>
                                         <Line.Y1>
-                                            <MultiBinding Converter="{StaticResource ToScreen}" ConverterParameter="y">
-                                                <Binding Path="X"/>
-                                                <Binding Path="Y"/>
-                                                <Binding Path="DataContext.Scale" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetX" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetY" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.RotationDeg" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            </MultiBinding>
+                                            <Binding Path="ScreenY"/>
                                         </Line.Y1>
-
-                                        <!-- конец с весом -->
                                         <Line.X2>
-                                            <MultiBinding Converter="{StaticResource VectorEndW}" ConverterParameter="x">
-                                                <Binding Path="."/>
-                                                <Binding Path="DataContext.Scale" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetX" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetY" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings.VectorScaleBase" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.RotationDeg" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.MaxVVisible" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings.Version" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            </MultiBinding>
+                                            <Binding Path="ArrowEndX"/>
                                         </Line.X2>
                                         <Line.Y2>
-                                            <MultiBinding Converter="{StaticResource VectorEndW}" ConverterParameter="y">
-                                                <Binding Path="."/>
-                                                <Binding Path="DataContext.Scale" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetX" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetY" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings.VectorScaleBase" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.RotationDeg" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.MaxVVisible" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings.Version" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            </MultiBinding>
+                                            <Binding Path="ArrowEndY"/>
                                         </Line.Y2>
                                     </Line>
 
                                     <!-- наконечник -->
-                                    <Polygon>
+                                    <Polygon Points="{Binding ArrowHead}"
+                                             Visibility="{Binding HasVector, Converter={StaticResource BoolToVis}}">
                                         <Polygon.Fill>
                                             <MultiBinding Converter="{StaticResource CycleColorFromSettingsConverter}">
                                                 <Binding Path="CycleId"/>
@@ -197,20 +154,6 @@
                                                 <Binding Path="DataContext.VectorSettings.Version" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
                                             </MultiBinding>
                                         </Polygon.Fill>
-                                        <Polygon.Points>
-                                            <MultiBinding Converter="{StaticResource HeadW}">
-                                                <Binding Path="."/>
-                                                <Binding Path="DataContext.Scale" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetX" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetY" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings.VectorScaleBase" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings.ArrowHeadSize" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.RotationDeg" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.MaxVVisible" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.VectorSettings.Version" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            </MultiBinding>
-                                        </Polygon.Points>
                                     </Polygon>
 
                                     <!-- подпись -->
@@ -218,22 +161,10 @@
                                                FontSize="{Binding DataContext.VectorSettings.LabelFontSize, RelativeSource={RelativeSource AncestorType=UserControl}}"
                                                Visibility="{Binding DataContext.VectorSettings.ShowLabels, RelativeSource={RelativeSource AncestorType=UserControl}, Converter={StaticResource BoolToVis}}">
                                         <Canvas.Left>
-                                            <MultiBinding Converter="{StaticResource ToScreen}" ConverterParameter="x">
-                                                <Binding Path="X"/><Binding Path="Y"/>
-                                                <Binding Path="DataContext.Scale" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetX" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetY" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.RotationDeg" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            </MultiBinding>
+                                            <Binding Path="LabelX"/>
                                         </Canvas.Left>
                                         <Canvas.Top>
-                                            <MultiBinding Converter="{StaticResource ToScreen}" ConverterParameter="y">
-                                                <Binding Path="X"/><Binding Path="Y"/>
-                                                <Binding Path="DataContext.Scale" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetX" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.OffsetY" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                                <Binding Path="DataContext.RotationDeg" RelativeSource="{RelativeSource AncestorType=UserControl}"/>
-                                            </MultiBinding>
+                                            <Binding Path="LabelY"/>
                                         </Canvas.Top>
                                     </TextBlock>
                                 </Canvas>

--- a/Views/VectorDisplaySettingsWindow.xaml
+++ b/Views/VectorDisplaySettingsWindow.xaml
@@ -144,7 +144,10 @@
                     <StackPanel>
                         <StackPanel Orientation="Horizontal">
                             <CheckBox Content="Один цвет для всех" IsChecked="{Binding VectorSettings.UseSingleColor, Mode=TwoWay}"/>
-                            <Rectangle Width="24" Height="18" Stroke="Black" Margin="12,2,6,0" Fill="{Binding VectorSettings.SingleColor}"/>
+                            <Rectangle Width="24" Height="18" Stroke="Black" Margin="12,2,4,0" Fill="{Binding VectorSettings.SingleColor}"/>
+                            <Button Width="32" Height="24" Margin="0,0,6,0" Click="OnPickSingleColorClick" ToolTip="Выбрать цвет">
+                                <TextBlock Text="&#xE790;" FontFamily="Segoe MDL2 Assets" FontSize="16" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Button>
                             <TextBox Width="90" Text="{Binding VectorSettings.SingleColor, Mode=TwoWay, Converter={StaticResource ColorToHex}}"/>
                         </StackPanel>
 
@@ -156,7 +159,10 @@
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">
-                                                <Rectangle Width="24" Height="18" Stroke="Black" Margin="0,0,6,0" Fill="{Binding Color}"/>
+                                                <Rectangle Width="24" Height="18" Stroke="Black" Margin="0,0,4,0" Fill="{Binding Color}"/>
+                                                <Button Width="28" Height="24" Margin="0,0,6,0" Click="OnPickCycleColorClick" ToolTip="Выбрать цвет">
+                                                    <TextBlock Text="&#xE790;" FontFamily="Segoe MDL2 Assets" FontSize="16" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                                                </Button>
                                                 <TextBox Width="90" Text="{Binding Color, Mode=TwoWay, Converter={StaticResource ColorToHex}}"/>
                                             </StackPanel>
                                         </DataTemplate>

--- a/Views/VectorDisplaySettingsWindow.xaml.cs
+++ b/Views/VectorDisplaySettingsWindow.xaml.cs
@@ -1,5 +1,10 @@
 ﻿// File: Views/VectorDisplaySettingsWindow.xaml.cs
+using System;
 using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using Osadka.ViewModels;
+using WinForms = System.Windows.Forms;
 
 namespace Osadka.Views
 {
@@ -10,5 +15,44 @@ namespace Osadka.Views
             InitializeComponent();
         }
         private void OnCloseClick(object sender, RoutedEventArgs e) => Close();
+
+        private void OnPickSingleColorClick(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not PitOffsetViewModel vm) return;
+            var selected = PickColor(vm.VectorSettings.SingleColor);
+            if (selected.HasValue)
+                vm.VectorSettings.SingleColor = selected.Value;
+        }
+
+        private void OnPickCycleColorClick(object sender, RoutedEventArgs e)
+        {
+            if ((sender as FrameworkElement)?.DataContext is not CycleStyle style) return;
+            var selected = PickColor(style.Color);
+            if (selected.HasValue)
+                style.Color = selected.Value;
+        }
+
+        private Color? PickColor(Color initial)
+        {
+            var dialog = new WinForms.ColorDialog
+            {
+                AllowFullOpen = true,
+                FullOpen = true,
+                AnyColor = true,
+                Color = System.Drawing.Color.FromArgb(initial.A, initial.R, initial.G, initial.B)
+            };
+
+            var helper = new WindowInteropHelper(this);
+            var owner = new Win32Window(helper.Handle);
+            return dialog.ShowDialog(owner) == WinForms.DialogResult.OK
+                ? Color.FromArgb(255, dialog.Color.R, dialog.Color.G, dialog.Color.B)
+                : (Color?)null;
+        }
+
+        private sealed class Win32Window : WinForms.IWin32Window
+        {
+            public Win32Window(IntPtr handle) => Handle = handle;
+            public IntPtr Handle { get; }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- reworked `PitOffsetViewModel` to cache cycle rows, compute screen geometry once, and rebuild overlays via `StreamGeometry` for more accurate fills and outlines
- simplified `PitOffsetPage` bindings to the new row projection properties and updated `PitConverters` so both vector colors and hatch brushes honour the display settings
- enabled Windows Forms colour dialogs and added palette buttons in the vector settings window for single and per-cycle colours

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c98896f178832091b002e476f92449