### PR TITLE
Add color picker interactions to vector settings

### DIFF
--- a/HorDeform.csproj
+++ b/HorDeform.csproj
@@ -9,6 +9,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>output-onlinepngtools.ico</ApplicationIcon>
     <FileUpgradeFlags>40</FileUpgradeFlags>
     <UpgradeBackupLocation>C:\Users\Gorji\source\repos\HorDeform\Backup\</UpgradeBackupLocation>

--- a/Views/VectorDisplaySettingsWindow.xaml
+++ b/Views/VectorDisplaySettingsWindow.xaml
@@ -144,7 +144,9 @@
                     <StackPanel>
                         <StackPanel Orientation="Horizontal">
                             <CheckBox Content="Один цвет для всех" IsChecked="{Binding VectorSettings.UseSingleColor, Mode=TwoWay}"/>
-                            <Rectangle Width="24" Height="18" Stroke="Black" Margin="12,2,6,0" Fill="{Binding VectorSettings.SingleColor}"/>
+                            <Button Width="24" Height="18" Margin="12,2,6,0" Padding="0" BorderBrush="Black" BorderThickness="1"
+                                    Background="{Binding VectorSettings.SingleColor}" ToolTip="Выбрать цвет"
+                                    Click="OnSelectSingleColorClick"/>
                             <TextBox Width="90" Text="{Binding VectorSettings.SingleColor, Mode=TwoWay, Converter={StaticResource ColorToHex}}"/>
                         </StackPanel>
 
@@ -156,7 +158,9 @@
                                     <DataGridTemplateColumn.CellTemplate>
                                         <DataTemplate>
                                             <StackPanel Orientation="Horizontal">
-                                                <Rectangle Width="24" Height="18" Stroke="Black" Margin="0,0,6,0" Fill="{Binding Color}"/>
+                                                <Button Width="24" Height="18" Margin="0,0,6,0" Padding="0" BorderBrush="Black" BorderThickness="1"
+                                                        Background="{Binding Color}" ToolTip="Выбрать цвет"
+                                                        Click="OnSelectCycleColorClick"/>
                                                 <TextBox Width="90" Text="{Binding Color, Mode=TwoWay, Converter={StaticResource ColorToHex}}"/>
                                             </StackPanel>
                                         </DataTemplate>

--- a/Views/VectorDisplaySettingsWindow.xaml.cs
+++ b/Views/VectorDisplaySettingsWindow.xaml.cs
@@ -1,5 +1,12 @@
-﻿// File: Views/VectorDisplaySettingsWindow.xaml.cs
+// File: Views/VectorDisplaySettingsWindow.xaml.cs
+using System;
 using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using System.Windows.Media;
+using Osadka.ViewModels;
+using DrawingColor = System.Drawing.Color;
+using WF = System.Windows.Forms;
 
 namespace Osadka.Views
 {
@@ -9,6 +16,51 @@ namespace Osadka.Views
         {
             InitializeComponent();
         }
+
         private void OnCloseClick(object sender, RoutedEventArgs e) => Close();
+
+        private void OnSelectSingleColorClick(object sender, RoutedEventArgs e)
+        {
+            if (DataContext is not PitOffsetViewModel { VectorSettings: { } settings }) return;
+            var current = settings.SingleColor;
+            if (TryPickColor(current, out var selected))
+                settings.SingleColor = selected;
+        }
+
+        private void OnSelectCycleColorClick(object sender, RoutedEventArgs e)
+        {
+            if (sender is not Button { DataContext: CycleStyle style }) return;
+            var current = style.Color;
+            if (TryPickColor(current, out var selected))
+                style.Color = selected;
+        }
+
+        private bool TryPickColor(Color initialColor, out Color selectedColor)
+        {
+            using var dialog = new WF.ColorDialog
+            {
+                AllowFullOpen = true,
+                AnyColor = true,
+                FullOpen = true,
+                Color = DrawingColor.FromArgb(initialColor.A, initialColor.R, initialColor.G, initialColor.B)
+            };
+
+            var ownerHandle = new WindowInteropHelper(this).Handle;
+            if (dialog.ShowDialog(new Win32Window(ownerHandle)) == WF.DialogResult.OK)
+            {
+                var color = dialog.Color;
+                selectedColor = Color.FromArgb(color.A, color.R, color.G, color.B);
+                return true;
+            }
+
+            selectedColor = initialColor;
+            return false;
+        }
+
+        private sealed class Win32Window : WF.IWin32Window
+        {
+            public Win32Window(IntPtr handle) => Handle = handle;
+            public IntPtr Handle { get; }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- replace static color preview rectangles with buttons that open a color selection dialog for single and per-cycle colors
- implement handlers to invoke a Windows Forms color picker and update the bound vector display settings
- enable Windows Forms support in the project so the color picker dialog can be used

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68c99cabffbc832087b62a0a6dc8f056