### PR TITLE
Update cycle fill converters and settings propagation

### DIFF
--- a/ViewModels/PitOffsetViewModel.cs
+++ b/ViewModels/PitOffsetViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.Win32;
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Globalization;
 using System.IO;
@@ -108,6 +109,10 @@ namespace Osadka.ViewModels
                 VectorSettings.Version++;
             };
 
+            VectorSettings.CycleStyles.CollectionChanged += OnCycleStylesCollectionChanged;
+            foreach (var style in VectorSettings.CycleStyles)
+                SubscribeCycleStyle(style);
+
             if (Objects.Count > 0) SelectedObject = Objects[0];
             RebuildCycles();
             RebuildRows();
@@ -145,6 +150,37 @@ namespace Osadka.ViewModels
             RebuildRows();
             RowsView.Refresh();
             RebuildCycleOverlays();
+        }
+
+        private void OnCycleStylesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+        {
+            if (e.OldItems != null)
+                foreach (CycleStyle style in e.OldItems.OfType<CycleStyle>())
+                    style.PropertyChanged -= OnCycleStylePropertyChanged;
+
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                foreach (var style in VectorSettings.CycleStyles)
+                    SubscribeCycleStyle(style);
+            }
+            else if (e.NewItems != null)
+            {
+                foreach (CycleStyle style in e.NewItems.OfType<CycleStyle>())
+                    SubscribeCycleStyle(style);
+            }
+
+            VectorSettings.Version++;
+        }
+
+        private void SubscribeCycleStyle(CycleStyle style)
+        {
+            style.PropertyChanged -= OnCycleStylePropertyChanged;
+            style.PropertyChanged += OnCycleStylePropertyChanged;
+        }
+
+        private void OnCycleStylePropertyChanged(object? sender, PropertyChangedEventArgs e)
+        {
+            VectorSettings.Version++;
         }
 
         private void SubscribeCycleToggle(CycleToggle ct)

--- a/Views/PitOffsetPage.xaml
+++ b/Views/PitOffsetPage.xaml
@@ -83,8 +83,7 @@
                                 <Grid>
                                     <Polygon Points="{Binding Points}"
                                              Visibility="{Binding HasFill, Converter={StaticResource BoolToVis}}"
-                                             StrokeThickness="2"
-                                             Opacity="{Binding DataContext.VectorSettings.FillOpacity, RelativeSource={RelativeSource AncestorType=UserControl}}">
+                                             StrokeThickness="2">
                                         <Polygon.Stroke>
                                             <MultiBinding Converter="{StaticResource CycleColorFromSettingsConverter}">
                                                 <Binding Path="CycleId"/>


### PR DESCRIPTION
## Summary
- use a shared helper so hatch and stroke colors resolve from VectorDisplaySettings with palette fallback
- update the hatch brush to honor fill and hatch opacities separately and refresh when settings change
- propagate VectorDisplaySettings cycle style updates by bumping the version and avoid double-applying fill opacity in XAML

## Testing
- `dotnet build` *(fails: dotnet not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c4f34948320bf7cb84fcece76a7